### PR TITLE
Allow multiple spaces between message parts

### DIFF
--- a/src/IrcClient/IrcClient.cs
+++ b/src/IrcClient/IrcClient.cs
@@ -824,7 +824,7 @@ namespace Meebey.SmartIrc4net
                 line = rawline;
             }
 
-            linear = line.Split(new char[] {' '});
+            linear = Regex.Split(line, @"\s+");
 
             // conform to RFC 2812
             from = linear[0];


### PR DESCRIPTION
The standard allows multiple spaces between message parts and some
servers do send such replies.