### PR TITLE
Add support for owner (~, +q) and admin (&, +a) non-RFC user statuses.

### DIFF
--- a/src/IrcClient/Delegates.cs
+++ b/src/IrcClient/Delegates.cs
@@ -39,6 +39,10 @@ namespace Meebey.SmartIrc4net
     public delegate void ListEventHandler(object sender, ListEventArgs e);
     public delegate void PartEventHandler(object sender, PartEventArgs e);
     public delegate void InviteEventHandler(object sender, InviteEventArgs e);
+    public delegate void OwnerEventHandler(object sender, OwnerEventArgs e);
+    public delegate void DeownerEventHandler(object sender, DeownerEventArgs e);
+    public delegate void ChannelAdminEventHandler(object sender, ChannelAdminEventArgs e);
+    public delegate void DeChannelAdminEventHandler(object sender, DeChannelAdminEventArgs e);
     public delegate void OpEventHandler(object sender, OpEventArgs e);
     public delegate void DeopEventHandler(object sender, DeopEventArgs e);
     public delegate void HalfopEventHandler(object sender, HalfopEventArgs e);

--- a/src/IrcClient/EventArgs.cs
+++ b/src/IrcClient/EventArgs.cs
@@ -643,212 +643,119 @@ namespace Meebey.SmartIrc4net
     }
 
     /// <summary>
-    ///
+    /// Event arguments for any change in channel role.
     /// </summary>
-    public class OpEventArgs : IrcEventArgs
+    public class ChannelRoleChangeEventArgs : IrcEventArgs
     {
-        private string   _Channel;
-        private string   _Who;
-        private string   _Whom;
-        
-        public string Channel {
-            get {
-                return _Channel;
-            }
-        }
+        public string Channel { get; private set; }
+        public string Who { get; private set; }
+        public string Whom { get; private set; }
 
-        public string Who {
-            get {
-                return _Who;
-            }
-        }
-
-        public string Whom {
-            get {
-                return _Whom;
-            }
-        }
-        
-        internal OpEventArgs(IrcMessageData data, string channel, string who, string whom) : base(data)
+        internal ChannelRoleChangeEventArgs(IrcMessageData data, string channel, string who, string whom) : base(data)
         {
-            _Channel = channel;
-            _Who = who;
-            _Whom = whom;
+            Channel = channel;
+            Who = who;
+            Whom = whom;
         }
     }
 
     /// <summary>
-    ///
+    /// User gained owner status (non-RFC, channel mode +q, prefix ~).
     /// </summary>
-    public class DeopEventArgs : IrcEventArgs
+    public class OwnerEventArgs : ChannelRoleChangeEventArgs
     {
-        private string   _Channel;
-        private string   _Who;
-        private string   _Whom;
-        
-        public string Channel {
-            get {
-                return _Channel;
-            }
-        }
-
-        public string Who {
-            get {
-                return _Who;
-            }
-        }
-
-        public string Whom {
-            get {
-                return _Whom;
-            }
-        }
-        
-        internal DeopEventArgs(IrcMessageData data, string channel, string who, string whom) : base(data)
+        internal OwnerEventArgs(IrcMessageData data, string channel, string who, string whom) : base(data, channel, who, whom)
         {
-            _Channel = channel;
-            _Who = who;
-            _Whom = whom;
-        }
-    }
-    
-    /// <summary>
-    ///
-    /// </summary>
-    public class HalfopEventArgs : IrcEventArgs
-    {
-        private string   _Channel;
-        private string   _Who;
-        private string   _Whom;
-        
-        public string Channel {
-            get {
-                return _Channel;
-            }
-        }
-
-        public string Who {
-            get {
-                return _Who;
-            }
-        }
-
-        public string Whom {
-            get {
-                return _Whom;
-            }
-        }
-        
-        internal HalfopEventArgs(IrcMessageData data, string channel, string who, string whom) : base(data)
-        {
-            _Channel = channel;
-            _Who = who;
-            _Whom = whom;
         }
     }
 
     /// <summary>
-    ///
+    /// User lost owner status (non-RFC, channel mode -q).
     /// </summary>
-    public class DehalfopEventArgs : IrcEventArgs
+    public class DeownerEventArgs : ChannelRoleChangeEventArgs
     {
-        private string   _Channel;
-        private string   _Who;
-        private string   _Whom;
-        
-        public string Channel {
-            get {
-                return _Channel;
-            }
-        }
-
-        public string Who {
-            get {
-                return _Who;
-            }
-        }
-
-        public string Whom {
-            get {
-                return _Whom;
-            }
-        }
-        
-        internal DehalfopEventArgs(IrcMessageData data, string channel, string who, string whom) : base(data)
+        internal DeownerEventArgs(IrcMessageData data, string channel, string who, string whom) : base(data, channel, who, whom)
         {
-            _Channel = channel;
-            _Who = who;
-            _Whom = whom;
-        }
-    }
-    
-    /// <summary>
-    ///
-    /// </summary>
-    public class VoiceEventArgs : IrcEventArgs
-    {
-        private string   _Channel;
-        private string   _Who;
-        private string   _Whom;
-        
-        public string Channel {
-            get {
-                return _Channel;
-            }
-        }
-
-        public string Who {
-            get {
-                return _Who;
-            }
-        }
-
-        public string Whom {
-            get {
-                return _Whom;
-            }
-        }
-        
-        internal VoiceEventArgs(IrcMessageData data, string channel, string who, string whom) : base(data)
-        {
-            _Channel = channel;
-            _Who = who;
-            _Whom = whom;
         }
     }
 
     /// <summary>
-    ///
+    /// User gained channel admin status (non-RFC, channel mode +a, prefix &amp;).
     /// </summary>
-    public class DevoiceEventArgs : IrcEventArgs
+    public class ChannelAdminEventArgs : ChannelRoleChangeEventArgs
     {
-        private string   _Channel;
-        private string   _Who;
-        private string   _Whom;
-        
-        public string Channel {
-            get {
-                return _Channel;
-            }
-        }
-
-        public string Who {
-            get {
-                return _Who;
-            }
-        }
-
-        public string Whom {
-            get {
-                return _Whom;
-            }
-        }
-        
-        internal DevoiceEventArgs(IrcMessageData data, string channel, string who, string whom) : base(data)
+        internal ChannelAdminEventArgs(IrcMessageData data, string channel, string who, string whom) : base(data, channel, who, whom)
         {
-            _Channel = channel;
-            _Who = who;
-            _Whom = whom;
+        }
+    }
+
+    /// <summary>
+    /// User lost channel admin status (non-RFC, channel mode -a).
+    /// </summary>
+    public class DeChannelAdminEventArgs : ChannelRoleChangeEventArgs
+    {
+        internal DeChannelAdminEventArgs(IrcMessageData data, string channel, string who, string whom) : base(data, channel, who, whom)
+        {
+        }
+    }
+
+    /// <summary>
+    /// User gained op status (channel mode +o, prefix @).
+    /// </summary>
+    public class OpEventArgs : ChannelRoleChangeEventArgs
+    {
+        internal OpEventArgs(IrcMessageData data, string channel, string who, string whom) : base(data, channel, who, whom)
+        {
+        }
+    }
+
+    /// <summary>
+    /// User lost op status (channel mode -o).
+    /// </summary>
+    public class DeopEventArgs : ChannelRoleChangeEventArgs
+    {
+        internal DeopEventArgs(IrcMessageData data, string channel, string who, string whom) : base(data, channel, who, whom)
+        {
+        }
+    }
+
+    /// <summary>
+    /// User gained halfop status (non-RFC, channel mode +h, prefix %).
+    /// </summary>
+    public class HalfopEventArgs : ChannelRoleChangeEventArgs
+    {
+        internal HalfopEventArgs(IrcMessageData data, string channel, string who, string whom) : base(data, channel, who, whom)
+        {
+        }
+    }
+
+    /// <summary>
+    /// User lost halfop status (non-RFC, channel mode -h).
+    /// </summary>
+    public class DehalfopEventArgs : ChannelRoleChangeEventArgs
+    {
+        internal DehalfopEventArgs(IrcMessageData data, string channel, string who, string whom) : base(data, channel, who, whom)
+        {
+        }
+    }
+
+    /// <summary>
+    /// User gained voice status (channel mode +v, prefix +).
+    /// </summary>
+    public class VoiceEventArgs : ChannelRoleChangeEventArgs
+    {
+        internal VoiceEventArgs(IrcMessageData data, string channel, string who, string whom) : base(data, channel, who, whom)
+        {
+        }
+    }
+
+    /// <summary>
+    /// User lost voice status (channel mode -v).
+    /// </summary>
+    public class DevoiceEventArgs : ChannelRoleChangeEventArgs
+    {
+        internal DevoiceEventArgs(IrcMessageData data, string channel, string who, string whom) : base(data, channel, who, whom)
+        {
         }
     }
 

--- a/src/IrcClient/IrcClient.cs
+++ b/src/IrcClient/IrcClient.cs
@@ -113,6 +113,10 @@ namespace Meebey.SmartIrc4net
         public event InviteEventHandler         OnInvite;
         public event BanEventHandler            OnBan;
         public event UnbanEventHandler          OnUnban;
+        public event OwnerEventHandler          OnOwner;
+        public event DeownerEventHandler        OnDeowner;
+        public event ChannelAdminEventHandler   OnChannelAdmin;
+        public event DeChannelAdminEventHandler OnDeChannelAdmin;
         public event OpEventHandler             OnOp;
         public event DeopEventHandler           OnDeop;
         public event HalfopEventHandler         OnHalfop;
@@ -1373,6 +1377,8 @@ namespace Meebey.SmartIrc4net
             chan.UnsafeVoices.Remove(nickname);
             if (SupportNonRfc) {
                 NonRfcChannel nchan = (NonRfcChannel)chan;
+                nchan.UnsafeOwners.Remove(nickname);
+                nchan.UnsafeChannelAdmins.Remove(nickname);
                 nchan.UnsafeHalfops.Remove(nickname);
             } 
         }
@@ -1468,6 +1474,138 @@ namespace Meebey.SmartIrc4net
                             
                             if (OnDeop != null) {
                                 OnDeop(this, new DeopEventArgs(ircdata, ircdata.Channel, ircdata.Nick, temp));
+                            }
+                        }
+                    break;
+                    case 'q':
+                        if (SupportNonRfc) {
+                            temp = (string)parametersEnumerator.Current;
+                            parametersEnumerator.MoveNext();
+
+                            if (add) {
+                                if (ActiveChannelSyncing && channel != null) {
+                                    // sanity check
+                                    if (GetChannelUser(ircdata.Channel, temp) != null) {
+                                        // update the owner list
+                                        try {
+                                            ((NonRfcChannel)channel).UnsafeOwners.Add(temp, GetIrcUser(temp));
+#if LOG4NET
+                                            Logger.ChannelSyncing.Debug("added owner: "+temp+" to: "+ircdata.Channel);
+#endif
+                                        } catch (ArgumentException) {
+#if LOG4NET
+                                            Logger.ChannelSyncing.Debug("duplicate owner: "+temp+" in: "+ircdata.Channel+" not added");
+#endif
+                                        }
+
+                                        // update the user owner status
+                                        NonRfcChannelUser cuser = (NonRfcChannelUser)GetChannelUser(ircdata.Channel, temp);
+                                        cuser.IsOwner = true;
+#if LOG4NET
+                                        Logger.ChannelSyncing.Debug("set owner status: " + temp + " for: "+ircdata.Channel);
+#endif
+                                    } else {
+#if LOG4NET
+                                        Logger.ChannelSyncing.Error("_InterpretChannelMode(): GetChannelUser(" + ircdata.Channel + "," + temp + ") returned null! Ignoring...");
+#endif
+                                    }
+                                }
+
+                                if (OnOwner != null) {
+                                    OnOwner(this, new OwnerEventArgs(ircdata, ircdata.Channel, ircdata.Nick, temp));
+                                }
+                            }
+                            if (remove) {
+                                if (ActiveChannelSyncing && channel != null) {
+                                    // sanity check
+                                    if (GetChannelUser(ircdata.Channel, temp) != null) {
+                                        // update the owner list
+                                        ((NonRfcChannel)channel).UnsafeOwners.Remove(temp);
+#if LOG4NET
+                                        Logger.ChannelSyncing.Debug("removed owner: "+temp+" from: "+ircdata.Channel);
+#endif
+                                        // update the user owner status
+                                        NonRfcChannelUser cuser = (NonRfcChannelUser)GetChannelUser(ircdata.Channel, temp);
+                                        cuser.IsOwner = false;
+#if LOG4NET
+                                        Logger.ChannelSyncing.Debug("unset owner status: " + temp + " for: "+ircdata.Channel);
+#endif
+                                    } else {
+#if LOG4NET
+                                        Logger.ChannelSyncing.Error("_InterpretChannelMode(): GetChannelUser(" + ircdata.Channel + "," + temp + ") returned null! Ignoring...");
+#endif
+                                    }
+                                }
+
+                                if (OnDeowner != null) {
+                                    OnDeowner(this, new DeownerEventArgs(ircdata, ircdata.Channel, ircdata.Nick, temp));
+                                }
+                            }
+                        }
+                    break;
+                    case 'a':
+                        if (SupportNonRfc) {
+                            temp = (string)parametersEnumerator.Current;
+                            parametersEnumerator.MoveNext();
+
+                            if (add) {
+                                if (ActiveChannelSyncing && channel != null) {
+                                    // sanity check
+                                    if (GetChannelUser(ircdata.Channel, temp) != null) {
+                                        // update the channel admin list
+                                        try {
+                                            ((NonRfcChannel)channel).UnsafeChannelAdmins.Add(temp, GetIrcUser(temp));
+#if LOG4NET
+                                            Logger.ChannelSyncing.Debug("added channel admin: "+temp+" to: "+ircdata.Channel);
+#endif
+                                        } catch (ArgumentException) {
+#if LOG4NET
+                                            Logger.ChannelSyncing.Debug("duplicate channel admin: "+temp+" in: "+ircdata.Channel+" not added");
+#endif
+                                        }
+
+                                        // update the user channel admin status
+                                        NonRfcChannelUser cuser = (NonRfcChannelUser)GetChannelUser(ircdata.Channel, temp);
+                                        cuser.IsChannelAdmin = true;
+#if LOG4NET
+                                        Logger.ChannelSyncing.Debug("set channel admin status: " + temp + " for: "+ircdata.Channel);
+#endif
+                                    } else {
+#if LOG4NET
+                                        Logger.ChannelSyncing.Error("_InterpretChannelMode(): GetChannelUser(" + ircdata.Channel + "," + temp + ") returned null! Ignoring...");
+#endif
+                                    }
+                                }
+
+                                if (OnChannelAdmin != null) {
+                                    OnChannelAdmin(this, new ChannelAdminEventArgs(ircdata, ircdata.Channel, ircdata.Nick, temp));
+                                }
+                            }
+                            if (remove) {
+                                if (ActiveChannelSyncing && channel != null) {
+                                    // sanity check
+                                    if (GetChannelUser(ircdata.Channel, temp) != null) {
+                                        // update the channel admin list
+                                        ((NonRfcChannel)channel).UnsafeChannelAdmins.Remove(temp);
+#if LOG4NET
+                                        Logger.ChannelSyncing.Debug("removed channel admin: "+temp+" from: "+ircdata.Channel);
+#endif
+                                        // update the user channel admin status
+                                        NonRfcChannelUser cuser = (NonRfcChannelUser)GetChannelUser(ircdata.Channel, temp);
+                                        cuser.IsChannelAdmin = false;
+#if LOG4NET
+                                        Logger.ChannelSyncing.Debug("unset channel admin status: " + temp + " for: "+ircdata.Channel);
+#endif
+                                    } else {
+#if LOG4NET
+                                        Logger.ChannelSyncing.Error("_InterpretChannelMode(): GetChannelUser(" + ircdata.Channel + "," + temp + ") returned null! Ignoring...");
+#endif
+                                    }
+                                }
+
+                                if (OnDeChannelAdmin != null) {
+                                    OnDeChannelAdmin(this, new DeChannelAdminEventArgs(ircdata, ircdata.Channel, ircdata.Nick, temp));
+                                }
                             }
                         }
                     break;
@@ -2094,6 +2232,16 @@ namespace Meebey.SmartIrc4net
                         // remove first to avoid duplication, Foo -> foo
                         channel.UnsafeUsers.Remove(oldnickname);
                         channel.UnsafeUsers.Add(newnickname, channeluser);
+                        if (SupportNonRfc && ((NonRfcChannelUser)channeluser).IsOwner) {
+                            NonRfcChannel nchannel = (NonRfcChannel)channel;
+                            nchannel.UnsafeOwners.Remove(oldnickname);
+                            nchannel.UnsafeOwners.Add(newnickname, channeluser);
+                        }
+                        if (SupportNonRfc && ((NonRfcChannelUser)channeluser).IsChannelAdmin) {
+                            NonRfcChannel nchannel = (NonRfcChannel)channel;
+                            nchannel.UnsafeChannelAdmins.Remove(oldnickname);
+                            nchannel.UnsafeChannelAdmins.Add(newnickname, channeluser);
+                        }
                         if (channeluser.IsOp) {
                             channel.UnsafeOps.Remove(oldnickname);
                             channel.UnsafeOps.Add(newnickname, channeluser);
@@ -2258,6 +2406,8 @@ namespace Meebey.SmartIrc4net
             if (ActiveChannelSyncing &&
                 IsJoined(channelname)) {
                 string nickname;
+                bool   owner;
+                bool   chanadmin;
                 bool   op;
                 bool   halfop;
                 bool   voice;
@@ -2266,10 +2416,20 @@ namespace Meebey.SmartIrc4net
                         continue;
                     }
 
+                    owner = false;
+                    chanadmin = false;
                     op = false;
                     halfop = false;
                     voice = false;
                     switch (user[0]) {
+                        case '~':
+                            owner = true;
+                            nickname = user.Substring(1);
+                        break;
+                        case '&':
+                            chanadmin = true;
+                            nickname = user.Substring(1);
+                        break;
                         case '@':
                             op = true;
                             nickname = user.Substring(1);
@@ -2278,16 +2438,8 @@ namespace Meebey.SmartIrc4net
                             voice = true;
                             nickname = user.Substring(1);
                         break;
-                        // RFC VIOLATION
-                        // some IRC network do this and break our channel sync...
-                        case '&':
-                            nickname = user.Substring(1);
-                        break;
                         case '%':
                             halfop = true;
-                            nickname = user.Substring(1);
-                        break;
-                        case '~':
                             nickname = user.Substring(1);
                         break;
                         default:
@@ -2315,6 +2467,18 @@ namespace Meebey.SmartIrc4net
                         Channel channel = GetChannel(channelname);
                         
                         channel.UnsafeUsers.Add(nickname, channeluser);
+                        if (SupportNonRfc && owner) {
+                            ((NonRfcChannel)channel).UnsafeOwners.Add(nickname, channeluser);
+#if LOG4NET
+                            Logger.ChannelSyncing.Debug("added owner: "+nickname+" to: "+channelname);
+#endif
+                        }
+                        if (SupportNonRfc && chanadmin) {
+                            ((NonRfcChannel)channel).UnsafeChannelAdmins.Add(nickname, channeluser);
+#if LOG4NET
+                            Logger.ChannelSyncing.Debug("added channel admin: "+nickname+" to: "+channelname);
+#endif
+                        }
                         if (op) {
                             channel.UnsafeOps.Add(nickname, channeluser);
 #if LOG4NET
@@ -2338,7 +2502,10 @@ namespace Meebey.SmartIrc4net
                     channeluser.IsOp    = op;
                     channeluser.IsVoice = voice;
                     if (SupportNonRfc) {
-                        ((NonRfcChannelUser)channeluser).IsHalfop = halfop;
+                        var nchanneluser = (NonRfcChannelUser)channeluser;
+                        nchanneluser.IsOwner = owner;
+                        nchanneluser.IsChannelAdmin = chanadmin;
+                        nchanneluser.IsHalfop = halfop;
                     }
                 }
             }

--- a/src/IrcClient/NonRfcChannel.cs
+++ b/src/IrcClient/NonRfcChannel.cs
@@ -37,8 +37,10 @@ namespace Meebey.SmartIrc4net
     /// <threadsafety static="true" instance="true" />
     public class NonRfcChannel : Channel
     {
+        private Hashtable _Owners = Hashtable.Synchronized(new Hashtable(new CaseInsensitiveHashCodeProvider(), new CaseInsensitiveComparer()));
+        private Hashtable _ChannelAdmins = Hashtable.Synchronized(new Hashtable(new CaseInsensitiveHashCodeProvider(), new CaseInsensitiveComparer()));
         private Hashtable _Halfops = Hashtable.Synchronized(new Hashtable(new CaseInsensitiveHashCodeProvider(), new CaseInsensitiveComparer()));
-        
+
         /// <summary>
         /// 
         /// </summary>
@@ -53,6 +55,46 @@ namespace Meebey.SmartIrc4net
             Logger.ChannelSyncing.Debug("NonRfcChannel ("+Name+") destroyed");
         }
 #endif
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <value> </value>
+        public Hashtable Owners {
+            get {
+                return (Hashtable) _Owners.Clone();
+            }
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <value> </value>
+        internal Hashtable UnsafeOwners {
+            get {
+                return _Owners;
+            }
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <value> </value>
+        public Hashtable ChannelAdmins {
+            get {
+                return (Hashtable) _ChannelAdmins.Clone();
+            }
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <value> </value>
+        internal Hashtable UnsafeChannelAdmins {
+            get {
+                return _ChannelAdmins;
+            }
+        }
 
         /// <summary>
         /// 

--- a/src/IrcClient/NonRfcChannelUser.cs
+++ b/src/IrcClient/NonRfcChannelUser.cs
@@ -34,9 +34,9 @@ namespace Meebey.SmartIrc4net
     /// <threadsafety static="true" instance="true" />
     public class NonRfcChannelUser : ChannelUser
     {
-        private bool _IsHalfop;
-        private bool _IsOwner;
-        private bool _IsAdmin;
+        public bool IsOwner { get; set; }
+        public bool IsChannelAdmin { get; set; }
+        public bool IsHalfop { get; set; }
         
         /// <summary>
         /// 
@@ -53,18 +53,5 @@ namespace Meebey.SmartIrc4net
             Logger.ChannelSyncing.Debug("NonRfcChannelUser ("+Channel+":"+IrcUser.Nick+") destroyed");
         }
 #endif
-
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <value> </value>
-        public bool IsHalfop {
-            get {
-                return _IsHalfop;
-            }
-            set {
-                _IsHalfop = value;
-            }
-        }
     }
 }

--- a/src/IrcClient/WhoInfo.cs
+++ b/src/IrcClient/WhoInfo.cs
@@ -41,7 +41,10 @@ namespace Meebey.SmartIrc4net
         private int      f_HopCount;
         private string   f_Realname;
         private bool     f_IsAway;
+        private bool     f_IsOwner;
+        private bool     f_IsChannelAdmin;
         private bool     f_IsOp;
+        private bool     f_IsHalfop;
         private bool     f_IsVoice;
         private bool     f_IsIrcOp;
         private bool     f_IsRegistered;
@@ -94,9 +97,27 @@ namespace Meebey.SmartIrc4net
             }
         }
 
+        public bool IsOwner {
+            get {
+                return f_IsOwner;
+            }
+        }
+
+        public bool IsChannelAdmin {
+            get {
+                return f_IsChannelAdmin;
+            }
+        }
+
         public bool IsOp {
             get {
                 return f_IsOp;
+            }
+        }
+
+        public bool IsHalfop {
+            get {
+                return f_IsHalfop;
             }
         }
 
@@ -151,7 +172,10 @@ namespace Meebey.SmartIrc4net
             }
 
             string usermode = data.RawMessageArray[8];
+            bool owner = false;
+            bool chanadmin = false;
             bool op = false;
+            bool halfop = false;
             bool voice = false;
             bool ircop = false;
             bool away = false;
@@ -165,8 +189,17 @@ namespace Meebey.SmartIrc4net
                     case 'G':
                         away = true;
                     break;
+                    case '~':
+                        owner = true;
+                    break;
+                    case '&':
+                        chanadmin = true;
+                    break;
                     case '@':
                         op = true;
+                    break;
+                    case '%':
+                        halfop = true;
                     break;
                     case '+':
                         voice = true;
@@ -180,7 +213,10 @@ namespace Meebey.SmartIrc4net
                 }
             }
             whoInfo.f_IsAway = away;
+            whoInfo.f_IsOwner = owner;
+            whoInfo.f_IsChannelAdmin = chanadmin;
             whoInfo.f_IsOp = op;
+            whoInfo.f_IsHalfop = halfop;
             whoInfo.f_IsVoice = voice;
             whoInfo.f_IsIrcOp = ircop;
 

--- a/src/IrcCommands/IrcCommands.cs
+++ b/src/IrcCommands/IrcCommands.cs
@@ -134,155 +134,107 @@ namespace Meebey.SmartIrc4net
             SendReply(data, message, Priority.Medium);
         }
         
+
         /// <summary>
-        /// 
+        /// Give or take a user's privilege in a channel.
         /// </summary>
-        /// <param name="channel"></param>
-        /// <param name="nickname"></param>
-        /// <param name="priority"></param>
-        public void Op(string channel, string nickname, Priority priority)
+        /// <param name="modechg">The mode change (e.g. +o) to perform on the user.</param>
+        /// <param name="channel">The channel in which to perform the privilege change.</param>
+        /// <param name="nickname">The nickname of the user whose privilege is being changed.</param>
+        /// <param name="priority">The priority with which the mode-setting message should be sent.</param>
+        public void ChangeChannelPrivilege(string modechg, string channel, string nickname, Priority priority)
         {
-            WriteLine(Rfc2812.Mode(channel, "+o "+nickname), priority);
+            WriteLine(Rfc2812.Mode(channel, modechg + " " + nickname), priority);
         }
 
         /// <summary>
-        ///
+        /// Give or take a user's privilege in a channel.
         /// </summary>
-        /// <param name="channel"></param>
-        /// <param name="nickname"></param>
-        public void Op(string channel, string[] nicknames)
+        /// <param name="modechg">The mode change (e.g. +o) to perform on the user.</param>
+        /// <param name="channel">The channel in which to perform the privilege change.</param>
+        /// <param name="nickname">The nickname of the user whose privilege is being changed.</param>
+        public void ChangeChannelPrivilege(string modechg, string channel, string nickname)
+        {
+            WriteLine(Rfc2812.Mode(channel, modechg + " " + nickname));
+        }
+
+        /// <summary>
+        /// Give or take a privilege to/from multiple users in a channel.
+        /// </summary>
+        /// <param name="modechg">The mode change (e.g. +o) to perform on the users.</param>
+        /// <param name="channel">The channel in which to give the users a privilege.</param>
+        /// <param name="nickname">The nicknames of the users receiving the privilege.</param>
+        public void ChangeChannelPrivilege(string modechg, string channel, string[] nicknames)
         {
             if (nicknames == null) {
                 throw new ArgumentNullException("nicknames");
             }
-            
+
             string[] modes = new string[nicknames.Length];
             for (int i = 0; i < nicknames.Length; i++) {
-                modes[i] = "+o";
+                modes[i] = modechg;
             }
             Mode(channel, modes, nicknames);
+        }
+
+        public void Op(string channel, string nickname, Priority priority)
+        {
+            ChangeChannelPrivilege("+o", channel, nickname, priority);
+        }
+
+        public void Op(string channel, string[] nicknames)
+        {
+            ChangeChannelPrivilege("+o", channel, nicknames);
         }
 
         public void Op(string channel, string nickname)
         {
-            WriteLine(Rfc2812.Mode(channel, "+o "+nickname));
+            ChangeChannelPrivilege("+o", channel, nickname);
         }
-        
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="channel"></param>
-        /// <param name="nickname"></param>
-        /// <param name="priority"></param>
+
         public void Deop(string channel, string nickname, Priority priority)
         {
-            WriteLine(Rfc2812.Mode(channel, "-o "+nickname), priority);
+            ChangeChannelPrivilege("-o", channel, nickname, priority);
         }
 
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="channel"></param>
-        /// <param name="nickname"></param>
-        public void Deop(string channel, string nickname)
-        {
-            WriteLine(Rfc2812.Mode(channel, "-o "+nickname));
-        }
-
-        /// <summary>
-        ///
-        /// </summary>
-        /// <param name="channel"></param>
-        /// <param name="nickname"></param>
         public void Deop(string channel, string[] nicknames)
         {
-            if (nicknames == null) {
-                throw new ArgumentNullException("nicknames");
-            }
-
-            string[] modes = new string[nicknames.Length];
-            for (int i = 0; i < nicknames.Length; i++) {
-                modes[i] = "-o";
-            }
-            Mode(channel, modes, nicknames);
+            ChangeChannelPrivilege("-o", channel, nicknames);
         }
 
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="channel"></param>
-        /// <param name="nickname"></param>
-        /// <param name="priority"></param>
+        public void Deop(string channel, string nickname)
+        {
+            ChangeChannelPrivilege("-o", channel, nickname);
+        }
+
         public void Voice(string channel, string nickname, Priority priority)
         {
-            WriteLine(Rfc2812.Mode(channel, "+v "+nickname), priority);
+            ChangeChannelPrivilege("+v", channel, nickname, priority);
         }
 
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="channel"></param>
-        /// <param name="nickname"></param>
-        public void Voice(string channel, string nickname)
-        {
-            WriteLine(Rfc2812.Mode(channel, "+v "+nickname));
-        }
-
-        /// <summary>
-        ///
-        /// </summary>
-        /// <param name="channel"></param>
-        /// <param name="nickname"></param>
         public void Voice(string channel, string[] nicknames)
         {
-            if (nicknames == null) {
-                throw new ArgumentNullException("nicknames");
-            }
-
-            string[] modes = new string[nicknames.Length];
-            for (int i = 0; i < nicknames.Length; i++) {
-                modes[i] = "+v";
-            }
-            Mode(channel, modes, nicknames);
+            ChangeChannelPrivilege("+v", channel, nicknames);
         }
 
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="channel"></param>
-        /// <param name="nickname"></param>
-        /// <param name="priority"></param>
+        public void Voice(string channel, string nickname)
+        {
+            ChangeChannelPrivilege("+v", channel, nickname);
+        }
+
         public void Devoice(string channel, string nickname, Priority priority)
         {
-            WriteLine(Rfc2812.Mode(channel, "-v "+nickname), priority);
+            ChangeChannelPrivilege("-v", channel, nickname, priority);
         }
 
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="channel"></param>
-        /// <param name="nickname"></param>
-        public void Devoice(string channel, string nickname)
-        {
-            WriteLine(Rfc2812.Mode(channel, "-v "+nickname));
-        }
-
-        /// <summary>
-        ///
-        /// </summary>
-        /// <param name="channel"></param>
-        /// <param name="nicknames"></param>
         public void Devoice(string channel, string[] nicknames)
         {
-            if (nicknames == null) {
-                throw new ArgumentNullException("nicknames");
-            }
+            ChangeChannelPrivilege("-v", channel, nicknames);
+        }
 
-            string[] modes = new string[nicknames.Length];
-            for (int i = 0; i < nicknames.Length; i++) {
-                modes[i] = "-v";
-            }
-            Mode(channel, modes, nicknames);
+        public void Devoice(string channel, string nickname)
+        {
+            ChangeChannelPrivilege("-v", channel, nickname);
         }
 
         /// <summary>
@@ -383,61 +335,95 @@ namespace Meebey.SmartIrc4net
         }
 
         // non-RFC commands
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="channel"></param>
-        /// <param name="nickname"></param>
-        /// <param name="priority"></param>
-        public void Halfop(string channel, string nickname)
+
+        public void Owner(string channel, string nickname, Priority priority)
         {
-            WriteLine(Rfc2812.Mode(channel, "+h "+nickname));
+            ChangeChannelPrivilege("+q", channel, nickname, priority);
         }
 
-        /// <summary>
-        ///
-        /// </summary>
-        /// <param name="channel"></param>
-        /// <param name="nicknames"></param>
+        public void Owner(string channel, string[] nicknames)
+        {
+            ChangeChannelPrivilege("+q", channel, nicknames);
+        }
+
+        public void Owner(string channel, string nickname)
+        {
+            ChangeChannelPrivilege("+q", channel, nickname);
+        }
+
+        public void Deowner(string channel, string nickname, Priority priority)
+        {
+            ChangeChannelPrivilege("-q", channel, nickname, priority);
+        }
+
+        public void Deowner(string channel, string[] nicknames)
+        {
+            ChangeChannelPrivilege("-q", channel, nicknames);
+        }
+
+        public void Deowner(string channel, string nickname)
+        {
+            ChangeChannelPrivilege("-q", channel, nickname);
+        }
+
+        public void ChanAdmin(string channel, string nickname, Priority priority)
+        {
+            ChangeChannelPrivilege("+a", channel, nickname, priority);
+        }
+
+        public void ChanAdmin(string channel, string[] nicknames)
+        {
+            ChangeChannelPrivilege("+a", channel, nicknames);
+        }
+
+        public void ChanAdmin(string channel, string nickname)
+        {
+            ChangeChannelPrivilege("+a", channel, nickname);
+        }
+
+        public void DeChanAdmin(string channel, string nickname, Priority priority)
+        {
+            ChangeChannelPrivilege("-a", channel, nickname, priority);
+        }
+
+        public void DeChanAdmin(string channel, string[] nicknames)
+        {
+            ChangeChannelPrivilege("-a", channel, nicknames);
+        }
+
+        public void DeChanAdmin(string channel, string nickname)
+        {
+            ChangeChannelPrivilege("-a", channel, nickname);
+        }
+
+        public void Halfop(string channel, string nickname, Priority priority)
+        {
+            ChangeChannelPrivilege("+h", channel, nickname, priority);
+        }
+
         public void Halfop(string channel, string[] nicknames)
         {
-            if (nicknames == null) {
-                throw new ArgumentNullException("nicknames");
-            }
-
-            string[] modes = new string[nicknames.Length];
-            for (int i = 0; i < nicknames.Length; i++) {
-                modes[i] = "+h";
-            }
-            Mode(channel, modes, nicknames);
+            ChangeChannelPrivilege("+h", channel, nicknames);
         }
 
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="channel"></param>
-        /// <param name="nickname"></param>
-        public void Dehalfop(string channel, string nickname)
+        public void Halfop(string channel, string nickname)
         {
-            WriteLine(Rfc2812.Mode(channel, "-h "+nickname));
+            ChangeChannelPrivilege("+h", channel, nickname);
         }
 
-        /// <summary>
-        ///
-        /// </summary>
-        /// <param name="channel"></param>
-        /// <param name="nicknames"></param>
+        public void Dehalfop(string channel, string nickname, Priority priority)
+        {
+            ChangeChannelPrivilege("-h", channel, nickname, priority);
+        }
+
         public void Dehalfop(string channel, string[] nicknames)
         {
-            if (nicknames == null) {
-                throw new ArgumentNullException("nicknames");
-            }
+            ChangeChannelPrivilege("-h", channel, nicknames);
+        }
 
-            string[] modes = new string[nicknames.Length];
-            for (int i = 0; i < nicknames.Length; i++) {
-                modes[i] = "-h";
-            }
-            Mode(channel, modes, nicknames);
+        public void Dehalfop(string channel, string nickname)
+        {
+            ChangeChannelPrivilege("-h", channel, nickname);
         }
 
         /// <summary>


### PR DESCRIPTION
Add support for the non-RFC channel user privilege statuses "owner" (nickname
prefix ~, channel mode +q) and "admin" (nickname prefix &, channel mode +a).
These are most commonly provided on UnrealIRCd-hosted servers, much like "halfop" (nickname prefix %, channel mode +h).
