### PR TITLE
Fix PREFIX misparse (closes #854).

### DIFF
--- a/src/IrcClient/ServerProperties.cs
+++ b/src/IrcClient/ServerProperties.cs
@@ -378,7 +378,7 @@ namespace Meebey.SmartIrc4net
                     return null;
                 }
 
-                var modesPrefixes = prefixstr.Split(')');
+                var modesPrefixes = prefixstr.Substring(1).Split(')');
                 if (modesPrefixes.Length != 2) {
                     // assuming the pathological case of a ')' mode
                     // character is impossible, this is invalid


### PR DESCRIPTION
Not skipping the leading '(' when splitting on the ')' always makes the modes list longer than the prefix list, which leads to an incorrect null return value.
