### PR TITLE
Use ordinal comparisons when parsing IRC messages. (Unicode bugfix)

### DIFF
--- a/src/IrcClient/IrcClient.cs
+++ b/src/IrcClient/IrcClient.cs
@@ -901,9 +901,9 @@ namespace Meebey.SmartIrc4net
             // conform to RFC 2812
             from = linear[0];
             messagecode = linear[1];
-            exclamationpos = from.IndexOf("!");
-            atpos = from.IndexOf("@");
-            colonpos = line.IndexOf(" :");
+            exclamationpos = from.IndexOf("!", StringComparison.Ordinal);
+            atpos = from.IndexOf("@", StringComparison.Ordinal);
+            colonpos = line.IndexOf(" :", StringComparison.Ordinal);
             if (colonpos != -1) {
                 // we want the exact position of ":" not beginning from the space
                 colonpos += 1;


### PR DESCRIPTION
Fixes a bug where messages starting with "combining" Unicode characters cause the parser to fail. Likely improves performance too.