### PR TITLE
avoid the following null pointer:

### DIFF
--- a/src/IrcClient/IrcClient.cs
+++ b/src/IrcClient/IrcClient.cs
@@ -966,6 +966,7 @@ namespace Meebey.SmartIrc4net
                 case ReplyCode.List:
                 case ReplyCode.ListEnd:
                 case ReplyCode.ErrorNoChannelModes:
+                case ReplyCode.InviteList:
                     channel = linear[3];
                     break;
             }


### PR DESCRIPTION
if the IrcClient._Worker handles a ReplyCode.InviteList
the MessageParser won't put a channel in
but _HandleEvents calls _Event_RPL_INVITELIST and there is a valid channel need
