### PR TITLE
fix: Listen() deadlock

### DIFF
--- a/src/IrcConnection/IrcConnection.cs
+++ b/src/IrcConnection/IrcConnection.cs
@@ -819,6 +819,9 @@ namespace Meebey.SmartIrc4net
             _IsConnected = false;
             _IsRegistered = false;
             
+            // signal ReadLine() to check IsConnected state
+            _ReadThread.QueuedEvent.Set();
+            
             IsDisconnecting = false;
             
             if (OnDisconnected != null) {


### PR DESCRIPTION
fix: Listen() should return when calling Disconnect() instead of being b.locked with ReadLine() waiting for WaitOne()