### PR TITLE
Remove . for default icon in benchmark.csproj

### DIFF
--- a/examples/benchmark/benchmark.csproj
+++ b/examples/benchmark/benchmark.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -8,7 +8,8 @@
     <ProjectGuid>{CD3D60C4-0A53-4B4C-B30C-1C4F2D68A21E}</ProjectGuid>
     <OutputType>Exe</OutputType>
     <RootNamespace>Benchmark</RootNamespace>
-    <ApplicationIcon>.</ApplicationIcon>
+    <ApplicationIcon>
+    </ApplicationIcon>
     <AssemblyName>benchmark</AssemblyName>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
A BOM creeps in. Visual Studio likes BOMs. :-1: But shouldn't hurt anything.
