### PR TITLE
.NET 4.0 obsolescence compliance, thread-safe issues, remove redundant code

### DIFF
--- a/SmartIrc4net.csproj
+++ b/SmartIrc4net.csproj
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -9,6 +9,8 @@
     <OutputType>Library</OutputType>
     <RootNamespace>SmartIrc4net</RootNamespace>
     <AssemblyName>Meebey.SmartIrc4net</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -24,6 +26,7 @@
     <Execution>
       <Execution clr-version="Net_2_0" />
     </Execution>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>none</DebugType>
@@ -37,9 +40,11 @@
     <Execution>
       <Execution clr-version="Net_2_0" />
     </Execution>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="src\AssemblyInfo.cs" />
+    <Compile Include="src\ConcurrentDictionaryEx.cs" />
     <Compile Include="src\Logger.cs" />
     <Compile Include="src\Consts.cs" />
     <Compile Include="src\EventArgs.cs" />

--- a/SmartIrc4net.sln
+++ b/SmartIrc4net.sln
@@ -1,6 +1,8 @@
 ﻿
-Microsoft Visual Studio Solution File, Format Version 11.00
-# Visual Studio 2010
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.23107.0
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SmartIrc4net", "SmartIrc4net.csproj", "{91D3003B-7E65-4EAF-8EE1-DA43832E7A9C}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "benchmark", "examples\benchmark\benchmark.csproj", "{CD3D60C4-0A53-4B4C-B30C-1C4F2D68A21E}"
@@ -15,26 +17,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "tests", "tests\tests.csproj
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Release|Any CPU = Release|Any CPU
 		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{154D83B3-A162-4886-B358-6188DBE376D7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{154D83B3-A162-4886-B358-6188DBE376D7}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{154D83B3-A162-4886-B358-6188DBE376D7}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{154D83B3-A162-4886-B358-6188DBE376D7}.Release|Any CPU.Build.0 = Release|Any CPU
-		{3F8CF2C1-EA37-444F-8693-A3A00B1131D2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{3F8CF2C1-EA37-444F-8693-A3A00B1131D2}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{3F8CF2C1-EA37-444F-8693-A3A00B1131D2}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{3F8CF2C1-EA37-444F-8693-A3A00B1131D2}.Release|Any CPU.Build.0 = Release|Any CPU
-		{65CBCA77-4241-4D4C-ACCB-E640D972CDC4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{65CBCA77-4241-4D4C-ACCB-E640D972CDC4}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{65CBCA77-4241-4D4C-ACCB-E640D972CDC4}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{65CBCA77-4241-4D4C-ACCB-E640D972CDC4}.Release|Any CPU.Build.0 = Release|Any CPU
-		{6F25C6EA-D1C3-47AA-8300-B6D5D6DE33B2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{6F25C6EA-D1C3-47AA-8300-B6D5D6DE33B2}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{6F25C6EA-D1C3-47AA-8300-B6D5D6DE33B2}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{6F25C6EA-D1C3-47AA-8300-B6D5D6DE33B2}.Release|Any CPU.Build.0 = Release|Any CPU
 		{91D3003B-7E65-4EAF-8EE1-DA43832E7A9C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{91D3003B-7E65-4EAF-8EE1-DA43832E7A9C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{91D3003B-7E65-4EAF-8EE1-DA43832E7A9C}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -43,6 +29,25 @@ Global
 		{CD3D60C4-0A53-4B4C-B30C-1C4F2D68A21E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CD3D60C4-0A53-4B4C-B30C-1C4F2D68A21E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CD3D60C4-0A53-4B4C-B30C-1C4F2D68A21E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6F25C6EA-D1C3-47AA-8300-B6D5D6DE33B2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6F25C6EA-D1C3-47AA-8300-B6D5D6DE33B2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6F25C6EA-D1C3-47AA-8300-B6D5D6DE33B2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6F25C6EA-D1C3-47AA-8300-B6D5D6DE33B2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{65CBCA77-4241-4D4C-ACCB-E640D972CDC4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{65CBCA77-4241-4D4C-ACCB-E640D972CDC4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{65CBCA77-4241-4D4C-ACCB-E640D972CDC4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{65CBCA77-4241-4D4C-ACCB-E640D972CDC4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3F8CF2C1-EA37-444F-8693-A3A00B1131D2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3F8CF2C1-EA37-444F-8693-A3A00B1131D2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3F8CF2C1-EA37-444F-8693-A3A00B1131D2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3F8CF2C1-EA37-444F-8693-A3A00B1131D2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{154D83B3-A162-4886-B358-6188DBE376D7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{154D83B3-A162-4886-B358-6188DBE376D7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{154D83B3-A162-4886-B358-6188DBE376D7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{154D83B3-A162-4886-B358-6188DBE376D7}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		StartupItem = SmartIrc4net.csproj
@@ -52,11 +57,10 @@ Global
 		$1.MessageStyle = $2
 		$2.LineAlign = 0
 		$1.inheritsSet = Mono
-		$0.TextStylePolicy = $3
+		$0.TextStylePolicy = $4
 		$3.inheritsSet = VisualStudio
 		$3.inheritsScope = text/plain
 		$3.scope = text/plain
-		$0.TextStylePolicy = $4
 		$4.inheritsSet = null
 		$4.scope = text/x-csharp
 		$0.CSharpFormattingPolicy = $5

--- a/examples/test/Test.cs
+++ b/examples/test/Test.cs
@@ -28,7 +28,6 @@
 
 using System;
 using System.Threading;
-using System.Collections;
 using System.Collections.Generic;
 
 using Meebey.SmartIrc4net;
@@ -66,9 +65,9 @@ public class Test
                 // hashtable key and nickname 
                 string nickname_list = "";
                 nickname_list += "Users: ";
-                foreach (DictionaryEntry de in channel.Users) {
-                    string      key         = (string)de.Key;
-                    ChannelUser channeluser = (ChannelUser)de.Value;
+                foreach (var de in channel.Users) {
+                    string      key         = de.Key;
+                    ChannelUser channeluser = de.Value;
                     nickname_list += "(";
                     if (channeluser.IsOp) {
                         nickname_list += "@";

--- a/src/ConcurrentDictionaryEx.cs
+++ b/src/ConcurrentDictionaryEx.cs
@@ -1,0 +1,60 @@
+﻿/*
+ * SmartIrc4net - the IRC library for .NET/C# <http://smartirc4net.sf.net>
+ *
+ * Copyright (c) 2015 Katy Coe <djkaty@start.no> <http://www.djkaty.com>
+ *
+ * Full LGPL License: <http://www.gnu.org/licenses/lgpl.txt>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+using System.Collections.Generic;
+using System.Collections.Concurrent;
+
+namespace Meebey.SmartIrc4net
+{
+    /// <summary>
+    /// Convenience extension methods to System.Collections.Concurrent.ConcurrentDictionary
+    /// </summary>
+    internal static class ConcurrentDictionaryEx
+    {
+        /// <summary>
+        /// Add a new item
+        /// </summary>
+        /// <typeparam name="TKey">Key type</typeparam>
+        /// <typeparam name="TValue">Value type</typeparam>
+        /// <param name="self">Dictionary to use</param>
+        /// <param name="key">New key</param>
+        /// <param name="value">New value</param>
+        /// <returns>True on success, false on failure</returns>
+        public static bool Add<TKey, TValue>(this ConcurrentDictionary<TKey, TValue> self, TKey key, TValue value)
+        {
+            return self.TryAdd(key, value);
+        }
+
+        /// <summary>
+        /// Remove an item
+        /// </summary>
+        /// <typeparam name="TKey">Key type</typeparam>
+        /// <typeparam name="TValue">Value type</typeparam>
+        /// <param name="self">Dictionary to use</param>
+        /// <param name="key">Key of item to remove</param>
+        /// <returns>True on success, false on failure</returns>
+        public static bool Remove<TKey, TValue>(this ConcurrentDictionary<TKey, TValue> self, TKey key)
+        {
+            return ((IDictionary<TKey, TValue>) self).Remove(key);
+        }
+    }
+}

--- a/src/EventArgs.cs
+++ b/src/EventArgs.cs
@@ -27,7 +27,6 @@
  */
 
 using System;
-using System.Collections.Specialized;
 
 namespace Meebey.SmartIrc4net
 {

--- a/src/IrcClient/BanInfo.cs
+++ b/src/IrcClient/BanInfo.cs
@@ -27,7 +27,6 @@
  */
 
 
-using System;
 
 namespace Meebey.SmartIrc4net
 {

--- a/src/IrcClient/Channel.cs
+++ b/src/IrcClient/Channel.cs
@@ -27,9 +27,10 @@
  */
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.Collections.Concurrent;
+using System.Linq;
 
 namespace Meebey.SmartIrc4net
 {
@@ -41,9 +42,9 @@ namespace Meebey.SmartIrc4net
     {
         private string           _Name;
         private string           _Key       = String.Empty;
-        private Hashtable        _Users     = Hashtable.Synchronized(new Hashtable(new CaseInsensitiveHashCodeProvider(), new CaseInsensitiveComparer()));
-        private Hashtable        _Ops       = Hashtable.Synchronized(new Hashtable(new CaseInsensitiveHashCodeProvider(), new CaseInsensitiveComparer()));
-        private Hashtable        _Voices    = Hashtable.Synchronized(new Hashtable(new CaseInsensitiveHashCodeProvider(), new CaseInsensitiveComparer()));
+        private ConcurrentDictionary<string, ChannelUser> _Users = new ConcurrentDictionary<string, ChannelUser>(StringComparer.OrdinalIgnoreCase);
+        private ConcurrentDictionary<string, ChannelUser> _Ops = new ConcurrentDictionary<string, ChannelUser>(StringComparer.OrdinalIgnoreCase);
+        private ConcurrentDictionary<string, ChannelUser> _Voices = new ConcurrentDictionary<string, ChannelUser>(StringComparer.OrdinalIgnoreCase);
         private StringCollection _Bans      = new StringCollection();
         private List<string>     _BanExcepts = new List<string>();
         private List<string>     _InviteExcepts = new List<string>();
@@ -99,9 +100,9 @@ namespace Meebey.SmartIrc4net
         /// 
         /// </summary>
         /// <value> </value>
-        public Hashtable Users {
+        public Dictionary<string, ChannelUser> Users {
             get {
-                return (Hashtable)_Users.Clone();
+                return _Users.ToDictionary(item => item.Key, item => item.Value);
             }
         }
 
@@ -109,7 +110,7 @@ namespace Meebey.SmartIrc4net
         /// 
         /// </summary>
         /// <value> </value>
-        internal Hashtable UnsafeUsers {
+        internal ConcurrentDictionary<string, ChannelUser> UnsafeUsers {
             get {
                 return _Users;
             }
@@ -119,9 +120,9 @@ namespace Meebey.SmartIrc4net
         /// 
         /// </summary>
         /// <value> </value>
-        public Hashtable Ops {
+        public Dictionary<string, ChannelUser> Ops {
             get {
-                return (Hashtable)_Ops.Clone();
+                return _Ops.ToDictionary(item => item.Key, item => item.Value);
             }
         }
 
@@ -129,7 +130,7 @@ namespace Meebey.SmartIrc4net
         /// 
         /// </summary>
         /// <value> </value>
-        internal Hashtable UnsafeOps {
+        internal ConcurrentDictionary<string, ChannelUser> UnsafeOps {
             get {
                 return _Ops;
             }
@@ -139,9 +140,9 @@ namespace Meebey.SmartIrc4net
         /// 
         /// </summary>
         /// <value> </value>
-        public Hashtable Voices {
+        public Dictionary<string, ChannelUser> Voices {
             get {
-                return (Hashtable)_Voices.Clone();
+                return _Voices.ToDictionary(item => item.Key, item => item.Value);
             }
         }
 
@@ -149,7 +150,7 @@ namespace Meebey.SmartIrc4net
         /// 
         /// </summary>
         /// <value> </value>
-        internal Hashtable UnsafeVoices {
+        internal ConcurrentDictionary<string, ChannelUser> UnsafeVoices {
             get {
                 return _Voices;
             }

--- a/src/IrcClient/ChannelInfo.cs
+++ b/src/IrcClient/ChannelInfo.cs
@@ -26,7 +26,6 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-using System;
 
 namespace Meebey.SmartIrc4net
 {

--- a/src/IrcClient/ChannelModeChangeInfo.cs
+++ b/src/IrcClient/ChannelModeChangeInfo.cs
@@ -18,7 +18,6 @@
 // along with this program; if not, write to the Free Software
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307 USA
 using System;
-using System.Linq;
 using System.Collections.Generic;
 
 namespace Meebey.SmartIrc4net

--- a/src/IrcClient/EventArgs.cs
+++ b/src/IrcClient/EventArgs.cs
@@ -27,7 +27,6 @@
  */
 
 using System;
-using System.Collections.Specialized;
 using System.Collections.Generic;
 
 namespace Meebey.SmartIrc4net

--- a/src/IrcClient/IrcClient.cs
+++ b/src/IrcClient/IrcClient.cs
@@ -31,7 +31,7 @@ using System;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
-using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 
@@ -54,7 +54,6 @@ namespace Meebey.SmartIrc4net
         private bool             _IsAway;
         private string           _CtcpVersion;
         private bool             _ActiveChannelSyncing;
-        private bool             _PassiveChannelSyncing;
         private bool             _AutoJoinOnInvite;
         private bool             _AutoRejoin;
         private Dictionary<string, string> _AutoRejoinChannels = new Dictionary<string, string>();
@@ -67,8 +66,8 @@ namespace Meebey.SmartIrc4net
         private bool             _MotdReceived;
         private Array            _ReplyCodes              = Enum.GetValues(typeof(ReplyCode));
         private StringCollection _JoinedChannels          = new StringCollection();
-        private Hashtable        _Channels                = Hashtable.Synchronized(new Hashtable(new CaseInsensitiveHashCodeProvider(), new CaseInsensitiveComparer()));
-        private Hashtable        _IrcUsers                = Hashtable.Synchronized(new Hashtable(new CaseInsensitiveHashCodeProvider(), new CaseInsensitiveComparer()));
+        private ConcurrentDictionary<string, Channel> _Channels = new ConcurrentDictionary<string, Channel>(StringComparer.OrdinalIgnoreCase);
+        private ConcurrentDictionary<string, IrcUser> _IrcUsers = new ConcurrentDictionary<string, IrcUser>(StringComparer.OrdinalIgnoreCase);
         private List<ChannelInfo> _ChannelList;
         private Object            _ChannelListSyncRoot = new Object();
         private AutoResetEvent    _ChannelListReceivedEvent;
@@ -177,27 +176,6 @@ namespace Meebey.SmartIrc4net
             }
         }
 
-        /// <summary>
-        /// Enables/disables the passive channel sync feature. Not implemented yet!
-        /// </summary>
-        public bool PassiveChannelSyncing {
-            get {
-                return _PassiveChannelSyncing;
-            }
-            /*
-            set {
-#if LOG4NET
-                if (value) {
-                    Logger.ChannelSyncing.Info("Passive channel syncing enabled");
-                } else {
-                    Logger.ChannelSyncing.Info("Passive channel syncing disabled");
-                }
-#endif
-                _PassiveChannelSyncing = value;
-            }
-            */
-        }
-        
         /// <summary>
         /// Sets the ctcp version that should be replied on ctcp version request.
         /// </summary>
@@ -699,7 +677,8 @@ namespace Meebey.SmartIrc4net
                 throw new System.ArgumentNullException("nickname");
             }
 
-            return (IrcUser)_IrcUsers[nickname];
+            IrcUser user;
+            return _IrcUsers.TryGetValue(nickname, out user) ? user : null;
         }
 
         /// <summary>
@@ -720,7 +699,8 @@ namespace Meebey.SmartIrc4net
             
             Channel channel = GetChannel(channelname);
             if (channel != null) {
-                return (ChannelUser)channel.UnsafeUsers[nickname];
+                ChannelUser cuser;
+                return channel.UnsafeUsers.TryGetValue(nickname, out cuser) ? cuser : null;
             } else {
                 return null;
             } 
@@ -736,8 +716,9 @@ namespace Meebey.SmartIrc4net
             if (channelname == null) {
                 throw new System.ArgumentNullException("channelname");
             }
-            
-            return (Channel)_Channels[channelname];
+
+            Channel channel;
+            return _Channels.TryGetValue(channelname, out channel) ? channel : null;
         }
 
         /// <summary>
@@ -1202,7 +1183,7 @@ namespace Meebey.SmartIrc4net
 #endif
             lock (_AutoRejoinChannels) {
                 _AutoRejoinChannels.Clear();
-                if (ActiveChannelSyncing || PassiveChannelSyncing) {
+                if (ActiveChannelSyncing) {
                     // store the key using channel sync
                     foreach (Channel channel in _Channels.Values) {
                         _AutoRejoinChannels.Add(channel.Name, channel.Key);
@@ -1641,10 +1622,12 @@ namespace Meebey.SmartIrc4net
                         if (add) {
                             if (ActiveChannelSyncing && channel != null) {
                                 // sanity check
-                                if (GetChannelUser(ircdata.Channel, temp) != null) {
+                                ChannelUser cuser = GetChannelUser(ircdata.Channel, temp);
+
+                                if (cuser != null) {
                                     // update the op list
                                     try {
-                                        channel.UnsafeOps.Add(temp, GetIrcUser(temp));
+                                        channel.UnsafeOps.Add(temp, cuser);
 #if LOG4NET
                                         Logger.ChannelSyncing.Debug("added op: "+temp+" to: "+ircdata.Channel);
 #endif
@@ -1655,7 +1638,6 @@ namespace Meebey.SmartIrc4net
                                     }
                                     
                                     // update the user op status
-                                    ChannelUser cuser = GetChannelUser(ircdata.Channel, temp);
                                     cuser.IsOp = true;
 #if LOG4NET
                                     Logger.ChannelSyncing.Debug("set op status: " + temp + " for: "+ircdata.Channel);
@@ -1703,10 +1685,12 @@ namespace Meebey.SmartIrc4net
                             if (add) {
                                 if (ActiveChannelSyncing && channel != null) {
                                     // sanity check
-                                    if (GetChannelUser(ircdata.Channel, temp) != null) {
+                                    NonRfcChannelUser cuser = (NonRfcChannelUser) GetChannelUser(ircdata.Channel, temp);
+
+                                    if (cuser != null) {
                                         // update the owner list
                                         try {
-                                            ((NonRfcChannel)channel).UnsafeOwners.Add(temp, GetIrcUser(temp));
+                                            ((NonRfcChannel)channel).UnsafeOwners.Add(temp, cuser);
 #if LOG4NET
                                             Logger.ChannelSyncing.Debug("added owner: "+temp+" to: "+ircdata.Channel);
 #endif
@@ -1717,7 +1701,6 @@ namespace Meebey.SmartIrc4net
                                         }
 
                                         // update the user owner status
-                                        NonRfcChannelUser cuser = (NonRfcChannelUser)GetChannelUser(ircdata.Channel, temp);
                                         cuser.IsOwner = true;
 #if LOG4NET
                                         Logger.ChannelSyncing.Debug("set owner status: " + temp + " for: "+ircdata.Channel);
@@ -1766,10 +1749,12 @@ namespace Meebey.SmartIrc4net
                             if (add) {
                                 if (ActiveChannelSyncing && channel != null) {
                                     // sanity check
-                                    if (GetChannelUser(ircdata.Channel, temp) != null) {
+                                    NonRfcChannelUser cuser = (NonRfcChannelUser) GetChannelUser(ircdata.Channel, temp);
+
+                                    if (cuser != null) {
                                         // update the channel admin list
                                         try {
-                                            ((NonRfcChannel)channel).UnsafeChannelAdmins.Add(temp, GetIrcUser(temp));
+                                            ((NonRfcChannel)channel).UnsafeChannelAdmins.Add(temp, cuser);
 #if LOG4NET
                                             Logger.ChannelSyncing.Debug("added channel admin: "+temp+" to: "+ircdata.Channel);
 #endif
@@ -1780,7 +1765,6 @@ namespace Meebey.SmartIrc4net
                                         }
 
                                         // update the user channel admin status
-                                        NonRfcChannelUser cuser = (NonRfcChannelUser)GetChannelUser(ircdata.Channel, temp);
                                         cuser.IsChannelAdmin = true;
 #if LOG4NET
                                         Logger.ChannelSyncing.Debug("set channel admin status: " + temp + " for: "+ircdata.Channel);
@@ -1829,10 +1813,12 @@ namespace Meebey.SmartIrc4net
                             if (add) {
                                 if (ActiveChannelSyncing && channel != null) {
                                     // sanity check
-                                    if (GetChannelUser(ircdata.Channel, temp) != null) {
+                                    NonRfcChannelUser cuser = (NonRfcChannelUser) GetChannelUser(ircdata.Channel, temp);
+
+                                    if (cuser != null) {
                                         // update the halfop list
                                         try {
-                                            ((NonRfcChannel)channel).UnsafeHalfops.Add(temp, GetIrcUser(temp));
+                                            ((NonRfcChannel)channel).UnsafeHalfops.Add(temp, cuser);
 #if LOG4NET
                                             Logger.ChannelSyncing.Debug("added halfop: "+temp+" to: "+ircdata.Channel);
 #endif
@@ -1843,7 +1829,6 @@ namespace Meebey.SmartIrc4net
                                         }
                                         
                                         // update the user halfop status
-                                        NonRfcChannelUser cuser = (NonRfcChannelUser)GetChannelUser(ircdata.Channel, temp);
                                         cuser.IsHalfop = true;
 #if LOG4NET
                                         Logger.ChannelSyncing.Debug("set halfop status: " + temp + " for: "+ircdata.Channel);
@@ -1891,10 +1876,12 @@ namespace Meebey.SmartIrc4net
                         if (add) {
                             if (ActiveChannelSyncing && channel != null) {
                                 // sanity check
-                                if (GetChannelUser(ircdata.Channel, temp) != null) {
+                                ChannelUser cuser = GetChannelUser(ircdata.Channel, temp);
+
+                                if (cuser != null) {
                                     // update the voice list
                                     try {
-                                        channel.UnsafeVoices.Add(temp, GetIrcUser(temp));
+                                        channel.UnsafeVoices.Add(temp, cuser);
 #if LOG4NET
                                         Logger.ChannelSyncing.Debug("added voice: "+temp+" to: "+ircdata.Channel);
 #endif
@@ -1905,7 +1892,6 @@ namespace Meebey.SmartIrc4net
                                     }
                                     
                                     // update the user voice status
-                                    ChannelUser cuser = GetChannelUser(ircdata.Channel, temp);
                                     cuser.IsVoice = true;
 #if LOG4NET
                                     Logger.ChannelSyncing.Debug("set voice status: " + temp + " for: "+ircdata.Channel);
@@ -2506,12 +2492,12 @@ namespace Meebey.SmartIrc4net
                         if (SupportNonRfc && ((NonRfcChannelUser)channeluser).IsOwner) {
                             NonRfcChannel nchannel = (NonRfcChannel)channel;
                             nchannel.UnsafeOwners.Remove(oldnickname);
-                            nchannel.UnsafeOwners.Add(newnickname, channeluser);
+                            nchannel.UnsafeOwners.Add(newnickname, (NonRfcChannelUser) channeluser);
                         }
                         if (SupportNonRfc && ((NonRfcChannelUser)channeluser).IsChannelAdmin) {
                             NonRfcChannel nchannel = (NonRfcChannel)channel;
                             nchannel.UnsafeChannelAdmins.Remove(oldnickname);
-                            nchannel.UnsafeChannelAdmins.Add(newnickname, channeluser);
+                            nchannel.UnsafeChannelAdmins.Add(newnickname, (NonRfcChannelUser) channeluser);
                         }
                         if (channeluser.IsOp) {
                             channel.UnsafeOps.Remove(oldnickname);
@@ -2520,7 +2506,7 @@ namespace Meebey.SmartIrc4net
                         if (SupportNonRfc && ((NonRfcChannelUser)channeluser).IsHalfop) {
                             NonRfcChannel nchannel = (NonRfcChannel)channel;
                             nchannel.UnsafeHalfops.Remove(oldnickname);
-                            nchannel.UnsafeHalfops.Add(newnickname, channeluser);
+                            nchannel.UnsafeHalfops.Add(newnickname, (NonRfcChannelUser) channeluser);
                         }
                         if (channeluser.IsVoice) {
                             channel.UnsafeVoices.Remove(oldnickname);
@@ -2749,13 +2735,13 @@ namespace Meebey.SmartIrc4net
                         
                         channel.UnsafeUsers.Add(nickname, channeluser);
                         if (SupportNonRfc && owner) {
-                            ((NonRfcChannel)channel).UnsafeOwners.Add(nickname, channeluser);
+                            ((NonRfcChannel)channel).UnsafeOwners.Add(nickname, (NonRfcChannelUser) channeluser);
 #if LOG4NET
                             Logger.ChannelSyncing.Debug("added owner: "+nickname+" to: "+channelname);
 #endif
                         }
                         if (SupportNonRfc && chanadmin) {
-                            ((NonRfcChannel)channel).UnsafeChannelAdmins.Add(nickname, channeluser);
+                            ((NonRfcChannel)channel).UnsafeChannelAdmins.Add(nickname, (NonRfcChannelUser) channeluser);
 #if LOG4NET
                             Logger.ChannelSyncing.Debug("added channel admin: "+nickname+" to: "+channelname);
 #endif
@@ -2767,7 +2753,7 @@ namespace Meebey.SmartIrc4net
 #endif
                         }
                         if (SupportNonRfc && halfop)  {
-                            ((NonRfcChannel)channel).UnsafeHalfops.Add(nickname, channeluser);
+                            ((NonRfcChannel)channel).UnsafeHalfops.Add(nickname, (NonRfcChannelUser) channeluser);
 #if LOG4NET
                             Logger.ChannelSyncing.Debug("added halfop: "+nickname+" to: "+channelname);
 #endif

--- a/src/IrcClient/NonRfcChannel.cs
+++ b/src/IrcClient/NonRfcChannel.cs
@@ -26,8 +26,10 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-using System.Collections;
-using System.Collections.Specialized;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Meebey.SmartIrc4net
 {
@@ -37,9 +39,9 @@ namespace Meebey.SmartIrc4net
     /// <threadsafety static="true" instance="true" />
     public class NonRfcChannel : Channel
     {
-        private Hashtable _Owners = Hashtable.Synchronized(new Hashtable(new CaseInsensitiveHashCodeProvider(), new CaseInsensitiveComparer()));
-        private Hashtable _ChannelAdmins = Hashtable.Synchronized(new Hashtable(new CaseInsensitiveHashCodeProvider(), new CaseInsensitiveComparer()));
-        private Hashtable _Halfops = Hashtable.Synchronized(new Hashtable(new CaseInsensitiveHashCodeProvider(), new CaseInsensitiveComparer()));
+        private ConcurrentDictionary<string, NonRfcChannelUser> _Owners = new ConcurrentDictionary<string, NonRfcChannelUser>(StringComparer.OrdinalIgnoreCase);
+        private ConcurrentDictionary<string, NonRfcChannelUser> _ChannelAdmins = new ConcurrentDictionary<string, NonRfcChannelUser>(StringComparer.OrdinalIgnoreCase);
+        private ConcurrentDictionary<string, NonRfcChannelUser> _Halfops = new ConcurrentDictionary<string, NonRfcChannelUser>(StringComparer.OrdinalIgnoreCase);
 
         /// <summary>
         /// 
@@ -60,9 +62,9 @@ namespace Meebey.SmartIrc4net
         /// 
         /// </summary>
         /// <value> </value>
-        public Hashtable Owners {
+        public Dictionary<string, NonRfcChannelUser> Owners {
             get {
-                return (Hashtable) _Owners.Clone();
+                return _Owners.ToDictionary(item => item.Key, item => item.Value);
             }
         }
 
@@ -70,7 +72,7 @@ namespace Meebey.SmartIrc4net
         /// 
         /// </summary>
         /// <value> </value>
-        internal Hashtable UnsafeOwners {
+        internal ConcurrentDictionary<string, NonRfcChannelUser> UnsafeOwners {
             get {
                 return _Owners;
             }
@@ -80,9 +82,9 @@ namespace Meebey.SmartIrc4net
         /// 
         /// </summary>
         /// <value> </value>
-        public Hashtable ChannelAdmins {
+        public Dictionary<string, NonRfcChannelUser> ChannelAdmins {
             get {
-                return (Hashtable) _ChannelAdmins.Clone();
+                return _ChannelAdmins.ToDictionary(item => item.Key, item => item.Value);
             }
         }
 
@@ -90,7 +92,7 @@ namespace Meebey.SmartIrc4net
         /// 
         /// </summary>
         /// <value> </value>
-        internal Hashtable UnsafeChannelAdmins {
+        internal ConcurrentDictionary<string, NonRfcChannelUser> UnsafeChannelAdmins {
             get {
                 return _ChannelAdmins;
             }
@@ -100,9 +102,9 @@ namespace Meebey.SmartIrc4net
         /// 
         /// </summary>
         /// <value> </value>
-        public Hashtable Halfops {
+        public Dictionary<string, NonRfcChannelUser> Halfops {
             get {
-                return (Hashtable) _Halfops.Clone();
+                return _Halfops.ToDictionary(item => item.Key, item => item.Value);
             }
         }
 
@@ -110,7 +112,7 @@ namespace Meebey.SmartIrc4net
         /// 
         /// </summary>
         /// <value> </value>
-        internal Hashtable UnsafeHalfops {
+        internal ConcurrentDictionary<string, NonRfcChannelUser> UnsafeHalfops {
             get {
                 return _Halfops;
             }

--- a/src/IrcCommands/IrcCommands.cs
+++ b/src/IrcCommands/IrcCommands.cs
@@ -28,7 +28,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace Meebey.SmartIrc4net
 {

--- a/src/IrcCommands/Rfc2812.cs
+++ b/src/IrcCommands/Rfc2812.cs
@@ -28,7 +28,6 @@
 
 using System;
 using System.Text;
-using System.Globalization;
 using System.Text.RegularExpressions;
 
 namespace Meebey.SmartIrc4net

--- a/src/IrcConnection/EventArgs.cs
+++ b/src/IrcConnection/EventArgs.cs
@@ -27,7 +27,6 @@
  */
 
 using System;
-using System.Collections.Specialized;
 
 namespace Meebey.SmartIrc4net
 {

--- a/src/IrcConnection/IrcProperties.cs
+++ b/src/IrcConnection/IrcProperties.cs
@@ -26,13 +26,6 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-using System;
-using System.IO;
-using System.Text;
-using System.Collections;
-using System.Threading;
-using System.Reflection;
-using System.Net.Sockets;
 
 namespace Meebey.SmartIrc4net
 {

--- a/src/IrcConnection/ProxyType.cs
+++ b/src/IrcConnection/ProxyType.cs
@@ -22,7 +22,6 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-using System;
 
 namespace Meebey.SmartIrc4net
 {

--- a/src/IrcFeatures/DccConnection.cs
+++ b/src/IrcFeatures/DccConnection.cs
@@ -3,6 +3,7 @@
  * SmartIrc4net - the IRC library for .NET/C# <http://smartirc4net.sf.net>
  *
  * Copyright (c) 2008-2009 Thomas Bruderer <apophis@apophis.ch> <http://www.apophis.ch>
+ * Copyright (c) 2015 Katy Coe <djkaty@start.no> <http://www.djkaty.com>
  * 
  * Full LGPL License: <http://www.gnu.org/licenses/lgpl.txt>
  *
@@ -22,9 +23,7 @@
  */
  
 using System;
-using System.IO;
 using System.Net;
-using System.Threading;
 using System.Net.Sockets;
 
 namespace Meebey.SmartIrc4net
@@ -194,11 +193,8 @@ namespace Meebey.SmartIrc4net
         #region protected Helper Functions
         protected long HostToDccInt(IPAddress ip)
         {
-            long temp = (ip.Address & 0xff) << 24;
-            temp |= (ip.Address & 0xff00)  << 8;
-            temp |= (ip.Address >> 8)  & 0xff00;
-            temp |= (ip.Address >> 24)  & 0xff;
-            return temp;
+            byte[] adb = ip.GetAddressBytes();
+            return (long) (ulong) (((adb[0] << 24) | (adb[1] << 16) | (adb[2] << 8) | adb[3]) & 0xffffffff);
         }
         
         protected string DccIntToHost(long ip)

--- a/src/IrcFeatures/DccSend.cs
+++ b/src/IrcFeatures/DccSend.cs
@@ -143,7 +143,7 @@ namespace Meebey.SmartIrc4net
                     
                     bytes = _File.Read(_Buffer, 0, _Buffer.Length);
                     try {
-                        Connection.GetStream().Write(_Buffer, 0, (int)bytes);
+                        Connection.GetStream().Write(_Buffer, 0, bytes);
                     } catch (IOException) {
                         bytes = 0;    // Connection Lost
                     }

--- a/src/IrcFeatures/EventArgs.cs
+++ b/src/IrcFeatures/EventArgs.cs
@@ -3,6 +3,7 @@
  * SmartIrc4net - the IRC library for .NET/C# <http://smartirc4net.sf.net>
  *
  * Copyright (c) 2008-2009 Thomas Bruderer <apophis@apophis.ch> <http://www.apophis.ch>
+ * Copyright (c) 2015 Katy Coe <djkaty@start.no> <http://www.djkaty.com>
  * 
  * Full LGPL License: <http://www.gnu.org/licenses/lgpl.txt>
  *
@@ -22,7 +23,6 @@
  */
  
 using System;
-using System.Collections.Generic;
 
 namespace Meebey.SmartIrc4net
 {

--- a/src/IrcFeatures/IrcConstants.cs
+++ b/src/IrcFeatures/IrcConstants.cs
@@ -21,7 +21,6 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-using System;
 
 namespace Meebey.SmartIrc4net
 {

--- a/src/Logger.cs
+++ b/src/Logger.cs
@@ -27,8 +27,6 @@
  */
 
 #if LOG4NET
-using System.IO;
-using System.Collections;
 using log4net;
 
 namespace Meebey.SmartIrc4net

--- a/tests/ChannelModeChangeInfoTests.cs
+++ b/tests/ChannelModeChangeInfoTests.cs
@@ -17,7 +17,6 @@
 //  You should have received a copy of the GNU Lesser General Public
 //  License along with this library; if not, write to the Free Software
 //  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
-using System;
 using System.Collections.Generic;
 using NUnit.Framework;
 

--- a/tests/DccTests.cs
+++ b/tests/DccTests.cs
@@ -1,0 +1,67 @@
+﻿/*
+ * SmartIrc4net - the IRC library for .NET/C# <http://smartirc4net.sf.net>
+ *
+ * Copyright (c) 2015 Katy Coe <djkaty@start.no> <http://www.djkaty.com>
+ *
+ * Full LGPL License: <http://www.gnu.org/licenses/lgpl.txt>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+using System;
+using System.Net;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Meebey.SmartIrc4net
+{
+    /// <summary>
+    /// Visual Studio Unit Testing Framework tests for DccConnection
+    /// </summary>
+    [TestClass]
+    public class DccTests
+    {
+        /// <summary>
+        /// Test DccConnection.HostToDccInt() as updated for .NET 4.0 compliance
+        /// </summary>
+        [TestMethod]
+        public void DccConnection_HostToDccInt()
+        {
+            // arbitrary IP addresses with bytes <0x80 and >=0x80 to test signed-ness
+            _Test_HostToDccInt("1.2.3.4");
+            _Test_HostToDccInt("128.1.2.254");
+        }
+
+        private void _Test_HostToDccInt(string ipstr)
+        {
+            IPAddress ip = IPAddress.Parse(ipstr);
+
+            PrivateObject o = new PrivateObject(typeof(DccConnection));
+
+            // Result of calling HostToDccInt() in .NET 4.5 code
+            long dccIntBytes = Convert.ToInt64(o.Invoke("HostToDccInt", ip));
+
+#pragma warning disable CS0618 // Type or member is obsolete
+                              // Compare result with old-style using obsolete IPAddress.Address property from old HostToDccInt() code
+            long temp = (ip.Address & 0xff) << 24;
+            temp |= (ip.Address & 0xff00) << 8;
+            temp |= (ip.Address >> 8) & 0xff00;
+            temp |= (ip.Address >> 24) & 0xff;
+#pragma warning restore CS0618 // Type or member is obsolete
+
+            Assert.AreEqual(dccIntBytes, temp);
+        }
+    }
+}

--- a/tests/tests.csproj
+++ b/tests/tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -28,6 +28,7 @@
     <ConsolePause>false</ConsolePause>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="System" />
     <Reference Include="nunit.framework">
       <Private>False</Private>
@@ -35,6 +36,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ChannelModeChangeInfoTests.cs" />
+    <Compile Include="DccTests.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
@@ -42,5 +44,8 @@
       <Project>{91D3003B-7E65-4EAF-8EE1-DA43832E7A9C}</Project>
       <Name>SmartIrc4net</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The commit does exactly what it says on the tin - gets rid of all the compiler warnings and moves the code forward to use .NET 4.0's type-safe and thread-safe Hashtable replacement containers and also makes a couple of small optimizations.

See: https://msdn.microsoft.com/en-us/library/dd287191(v=vs.110).aspx

I'm being quite anal about the code because I intend to use this library to process thousands of reads and writes per second on an auto-scale Azure cloud eventually, so it needs to work fast and safe :)

Maybe consider making an unstable branch rolling up this and the transport changes? And/or a .NET 4+ branch? Using async/await and TPL could become an option then in the future.
