### PR TITLE
IRCv3 capability negotation

### DIFF
--- a/SmartIrc4net.csproj
+++ b/SmartIrc4net.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -40,6 +40,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="src\AssemblyInfo.cs" />
+    <Compile Include="src\IrcCommands\Capability.cs" />
     <Compile Include="src\Logger.cs" />
     <Compile Include="src\Consts.cs" />
     <Compile Include="src\EventArgs.cs" />

--- a/SmartIrc4net.sln
+++ b/SmartIrc4net.sln
@@ -1,6 +1,8 @@
 ﻿
-Microsoft Visual Studio Solution File, Format Version 11.00
-# Visual Studio 2010
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.23107.0
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SmartIrc4net", "SmartIrc4net.csproj", "{91D3003B-7E65-4EAF-8EE1-DA43832E7A9C}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "benchmark", "examples\benchmark\benchmark.csproj", "{CD3D60C4-0A53-4B4C-B30C-1C4F2D68A21E}"
@@ -15,26 +17,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "tests", "tests\tests.csproj
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Release|Any CPU = Release|Any CPU
 		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{154D83B3-A162-4886-B358-6188DBE376D7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{154D83B3-A162-4886-B358-6188DBE376D7}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{154D83B3-A162-4886-B358-6188DBE376D7}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{154D83B3-A162-4886-B358-6188DBE376D7}.Release|Any CPU.Build.0 = Release|Any CPU
-		{3F8CF2C1-EA37-444F-8693-A3A00B1131D2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{3F8CF2C1-EA37-444F-8693-A3A00B1131D2}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{3F8CF2C1-EA37-444F-8693-A3A00B1131D2}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{3F8CF2C1-EA37-444F-8693-A3A00B1131D2}.Release|Any CPU.Build.0 = Release|Any CPU
-		{65CBCA77-4241-4D4C-ACCB-E640D972CDC4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{65CBCA77-4241-4D4C-ACCB-E640D972CDC4}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{65CBCA77-4241-4D4C-ACCB-E640D972CDC4}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{65CBCA77-4241-4D4C-ACCB-E640D972CDC4}.Release|Any CPU.Build.0 = Release|Any CPU
-		{6F25C6EA-D1C3-47AA-8300-B6D5D6DE33B2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{6F25C6EA-D1C3-47AA-8300-B6D5D6DE33B2}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{6F25C6EA-D1C3-47AA-8300-B6D5D6DE33B2}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{6F25C6EA-D1C3-47AA-8300-B6D5D6DE33B2}.Release|Any CPU.Build.0 = Release|Any CPU
 		{91D3003B-7E65-4EAF-8EE1-DA43832E7A9C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{91D3003B-7E65-4EAF-8EE1-DA43832E7A9C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{91D3003B-7E65-4EAF-8EE1-DA43832E7A9C}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -43,6 +29,25 @@ Global
 		{CD3D60C4-0A53-4B4C-B30C-1C4F2D68A21E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CD3D60C4-0A53-4B4C-B30C-1C4F2D68A21E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CD3D60C4-0A53-4B4C-B30C-1C4F2D68A21E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6F25C6EA-D1C3-47AA-8300-B6D5D6DE33B2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6F25C6EA-D1C3-47AA-8300-B6D5D6DE33B2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6F25C6EA-D1C3-47AA-8300-B6D5D6DE33B2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6F25C6EA-D1C3-47AA-8300-B6D5D6DE33B2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{65CBCA77-4241-4D4C-ACCB-E640D972CDC4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{65CBCA77-4241-4D4C-ACCB-E640D972CDC4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{65CBCA77-4241-4D4C-ACCB-E640D972CDC4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{65CBCA77-4241-4D4C-ACCB-E640D972CDC4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3F8CF2C1-EA37-444F-8693-A3A00B1131D2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3F8CF2C1-EA37-444F-8693-A3A00B1131D2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3F8CF2C1-EA37-444F-8693-A3A00B1131D2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3F8CF2C1-EA37-444F-8693-A3A00B1131D2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{154D83B3-A162-4886-B358-6188DBE376D7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{154D83B3-A162-4886-B358-6188DBE376D7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{154D83B3-A162-4886-B358-6188DBE376D7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{154D83B3-A162-4886-B358-6188DBE376D7}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		StartupItem = SmartIrc4net.csproj
@@ -52,11 +57,10 @@ Global
 		$1.MessageStyle = $2
 		$2.LineAlign = 0
 		$1.inheritsSet = Mono
-		$0.TextStylePolicy = $3
+		$0.TextStylePolicy = $4
 		$3.inheritsSet = VisualStudio
 		$3.inheritsScope = text/plain
 		$3.scope = text/plain
-		$0.TextStylePolicy = $4
 		$4.inheritsSet = null
 		$4.scope = text/x-csharp
 		$0.CSharpFormattingPolicy = $5

--- a/examples/test/Test.cs
+++ b/examples/test/Test.cs
@@ -110,13 +110,48 @@ public class Test
     {
         System.Console.WriteLine("Received: "+e.Data.RawMessage);
     }
-    
+
+    public static void OnCapLsReply(object sender, CapEventArgs e) {
+        Console.WriteLine("Available caps:");
+
+        foreach (var c in e.CapList) {
+            Console.WriteLine(c);
+        }
+
+        ((IrcClient) sender).CapReq(e.CapList);
+    }
+
+    public static void OnCapListReply(object sender, CapEventArgs e) {
+        Console.WriteLine("Activated caps:");
+
+        foreach (var c in e.CapList) {
+            Console.WriteLine(c);
+        }
+    }
+
+    public static void OnCapReqReply(object sender, CapEventArgs e) {
+        if (e.Data.Type == ReceiveType.CapAck)
+            Console.WriteLine("Allowed caps:");
+
+        if (e.Data.Type == ReceiveType.CapNak)
+            Console.WriteLine("Denied caps:");
+
+        foreach (var c in e.CapList) {
+            Console.WriteLine(c);
+        }
+
+        ((IrcClient) sender).CapList();
+    }
+
     public static void Main(string[] args)
     {
         Thread.CurrentThread.Name = "Main";
         
         // UTF-8 test
         irc.Encoding = System.Text.Encoding.UTF8;
+
+        // Enable IRCv3 protocol features
+        irc.UseIrcV3 = true;
         
         // wait time between messages, we can set this lower on own irc servers
         irc.SendDelay = 200;
@@ -129,6 +164,12 @@ public class Test
         irc.OnQueryMessage += new IrcEventHandler(OnQueryMessage);
         irc.OnError += new ErrorEventHandler(OnError);
         irc.OnRawMessage += new IrcEventHandler(OnRawMessage);
+
+        // Listen for caps messages
+        irc.OnCapLsReply += OnCapLsReply;
+        irc.OnCapListReply += OnCapListReply;
+        irc.OnCapAckReply += OnCapReqReply;
+        irc.OnCapNakReply += OnCapReqReply;
 
         string[] serverlist;
         // the server we want to connect to, could be also a simple string

--- a/src/Consts.cs
+++ b/src/Consts.cs
@@ -87,6 +87,10 @@ namespace Meebey.SmartIrc4net
         QueryNotice,
         CtcpReply,
         CtcpRequest,
+        CapLs,
+        CapList,
+        CapAck,
+        CapNak,
         Error,
         ErrorMessage,
         Unknown
@@ -191,6 +195,7 @@ namespace Meebey.SmartIrc4net
         ErrorTooManyTargets =            407,
         ErrorNoSuchService =             408,
         ErrorNoOrigin =                  409,
+        ErrorInvalidCapCommand =         410,
         ErrorNoRecipient =               411,
         ErrorNoTextToSend =              412,
         ErrorNoTopLevel =                413,

--- a/src/IrcClient/EventArgs.cs
+++ b/src/IrcClient/EventArgs.cs
@@ -29,6 +29,7 @@
 using System;
 using System.Collections.Specialized;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Meebey.SmartIrc4net
 {
@@ -151,6 +152,22 @@ namespace Meebey.SmartIrc4net
         internal PongEventArgs(IrcMessageData data, TimeSpan lag) : base(data)
         {
             _Lag = lag;
+        }
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public class CapEventArgs : IrcEventArgs
+    {
+        /// <summary>
+        /// List of capabilities
+        /// </summary>
+        public Capability[] CapList { get; }
+
+        internal CapEventArgs(IrcMessageData data, IEnumerable<Capability> caplist) : base(data)
+        {
+            CapList = caplist.ToArray();
         }
     }
 

--- a/src/IrcClient/IrcClient.cs
+++ b/src/IrcClient/IrcClient.cs
@@ -9,6 +9,7 @@
  *
  * Copyright (c) 2003-2010, 2012-2014 Mirco Bauer <meebey@meebey.net>
  * Copyright (c) 2008-2009 Thomas Bruderer <apophis@apophis.ch>
+ * Copyright (c) 2015 Katy Coe <djkaty@start.no> <http://www.djkaty.com>
  *
  * Full LGPL License: <http://www.gnu.org/licenses/lgpl.txt>
  *
@@ -53,6 +54,8 @@ namespace Meebey.SmartIrc4net
         private string           _Password                = string.Empty;
         private bool             _IsAway;
         private string           _CtcpVersion;
+        private bool             _UseIrcV3;
+        private List<Capability> _Caps;
         private bool             _ActiveChannelSyncing;
         private bool             _PassiveChannelSyncing;
         private bool             _AutoJoinOnInvite;
@@ -88,6 +91,10 @@ namespace Meebey.SmartIrc4net
         private static Regex     _ReplyCodeRegex          = new Regex("^:[^ ]+? ([0-9]{3}) .+$", RegexOptions.Compiled);
         private static Regex     _PingRegex               = new Regex("^PING :.*", RegexOptions.Compiled);
         private static Regex     _ErrorRegex              = new Regex("^ERROR :.*", RegexOptions.Compiled);
+        private static Regex     _CapLsRegex              = new Regex("^:.*? CAP .* LS (?:\\*\\s)?:.*$", RegexOptions.Compiled);
+        private static Regex     _CapListRegex            = new Regex("^:.*? CAP .* LIST (?:\\*\\s)?:.*$", RegexOptions.Compiled);
+        private static Regex     _CapAckRegex             = new Regex("^:.*? CAP .* ACK (?:\\*\\s)?:.*$", RegexOptions.Compiled);
+        private static Regex     _CapNakRegex             = new Regex("^:.*? CAP .* NAK (?:\\*\\s)?:.*$", RegexOptions.Compiled);
         private static Regex     _ActionRegex             = new Regex("^:.*? PRIVMSG (.).* :"+"\x1"+"ACTION .*"+"\x1"+"$", RegexOptions.Compiled);
         private static Regex     _CtcpRequestRegex        = new Regex("^:.*? PRIVMSG .* :"+"\x1"+".*"+"\x1"+"$", RegexOptions.Compiled);
         private static Regex     _MessageRegex            = new Regex("^:.*? PRIVMSG (.).* :.*$", RegexOptions.Compiled);
@@ -155,7 +162,44 @@ namespace Meebey.SmartIrc4net
         public event IrcEventHandler            OnQueryNotice;
         public event CtcpEventHandler           OnCtcpRequest;
         public event CtcpEventHandler           OnCtcpReply;
+        public event EventHandler<CapEventArgs> OnCapLsReply;
+        public event EventHandler<CapEventArgs> OnCapListReply;
+        public event EventHandler<CapEventArgs> OnCapAckReply;
+        public event EventHandler<CapEventArgs> OnCapNakReply;
         public event BounceEventHandler         OnBounce;
+
+        /// <summary>
+        /// Enables/disables the use of supported aspects of the IRC v3 protocol
+        /// Default: false
+        /// </summary>
+        public bool UseIrcV3 {
+            get {
+                return _UseIrcV3;
+            }
+            set {
+#if LOG4NET
+                if (value) {
+                    Logger.Connection.Info("IRC v3 enabled");
+                } else {
+                    Logger.Connection.Info("IRC v3 disabled");
+                }
+#endif
+                _UseIrcV3 = value;
+            }
+        }
+
+        /// <summary>
+        /// Enables/disables the use of supported aspects of the IRC v3 protocol
+        /// Default: false
+        /// </summary>
+        public List<Capability> Caps {
+            get {
+                return _Caps;
+            }
+            set {
+                _Caps = value;
+            }
+        }
 
         /// <summary>
         /// Enables/disables the active channel sync feature.
@@ -474,6 +518,11 @@ namespace Meebey.SmartIrc4net
             _SupportNonRfcLocked = true;
             ChannelModeMap = new ChannelModeMap();
             base.Connect(addresslist, port);
+
+            // We get here only if the connection is successful
+            if (_UseIrcV3) {
+                _CapNegotiateStart();
+            }
         }
         
         /// <overloads>
@@ -487,6 +536,11 @@ namespace Meebey.SmartIrc4net
                 _StoreChannelsToRejoin();
             }
             base.Reconnect();
+
+            if (_UseIrcV3) {
+                _CapNegotiateStart();
+            }
+
             if (login) {
                 //reset the nick to the original nicklist
                 _CurrentNickname = 0;
@@ -641,7 +695,14 @@ namespace Meebey.SmartIrc4net
         {
             Login(new string[] {nick, nick+"_", nick+"__"}, realname, 0, "", "");
         }
-        
+
+        /// <summary>
+        /// Start negotiating IRCv3 caps by getting a list of the available capabilities supported by the server
+        /// </summary>
+        private void _CapNegotiateStart() {
+            CapLs();
+        }
+
         /// <summary>
         /// Determine if a specifier nickname is you
         /// </summary>
@@ -1339,6 +1400,26 @@ namespace Meebey.SmartIrc4net
                 return ReceiveType.Unknown;
             }
 
+            found = _CapLsRegex.Match(rawline);
+            if (found.Success) {
+                return ReceiveType.CapLs;
+            }
+
+            found = _CapListRegex.Match(rawline);
+            if (found.Success) {
+                return ReceiveType.CapList;
+            }
+
+            found = _CapAckRegex.Match(rawline);
+            if (found.Success) {
+                return ReceiveType.CapAck;
+            }
+
+            found = _CapNakRegex.Match(rawline);
+            if (found.Success) {
+                return ReceiveType.CapNak;
+            }
+
             found = _ErrorRegex.Match(rawline);
             if (found.Success) {
                 return ReceiveType.Error;
@@ -1495,6 +1576,9 @@ namespace Meebey.SmartIrc4net
                 break;
                 case "PONG":
                     _Event_PONG(ircdata);
+                break;
+                case "CAP":
+                    _Event_CAP(ircdata);
                 break;
             }
 
@@ -2148,6 +2232,36 @@ namespace Meebey.SmartIrc4net
                 OnError(this, new ErrorEventArgs(ircdata, message));
             }
         }
+
+        /// <summary>
+        /// Event handler for CAP messages
+        /// </summary>
+        /// <param name="ircdata">Message data containing capability response</param>
+        private void _Event_CAP(IrcMessageData ircdata)
+        {
+            switch (ircdata.Type) {
+                case ReceiveType.CapLs:
+                    if (OnCapLsReply != null)
+                        OnCapLsReply(this, new CapEventArgs(ircdata, Capability.FromStrings(ircdata.Message)));
+                break;
+
+                case ReceiveType.CapList:
+                    if (OnCapListReply != null)
+                        OnCapListReply(this, new CapEventArgs(ircdata, Capability.FromStrings(ircdata.Message)));
+                break;
+
+                case ReceiveType.CapAck:
+                    if (OnCapAckReply != null)
+                        OnCapAckReply(this, new CapEventArgs(ircdata, Capability.FromStrings(ircdata.Message)));
+                break;
+
+                case ReceiveType.CapNak:
+                    if (OnCapNakReply != null)
+                        OnCapNakReply(this, new CapEventArgs(ircdata, Capability.FromStrings(ircdata.Message)));
+                break;
+            }
+        }
+
 
         /// <summary>
         /// Event handler for join messages

--- a/src/IrcCommands/Capability.cs
+++ b/src/IrcCommands/Capability.cs
@@ -1,0 +1,128 @@
+﻿/*
+ * $Id$
+ * $URL$
+ * $Rev$
+ * $Author$
+ * $Date$
+ *
+ * SmartIrc4net - the IRC library for .NET/C# <http://smartirc4net.sf.net>
+ *
+ * Copyright (c) 2003-2005 Mirco Bauer <meebey@meebey.net> <http://www.meebey.net>
+ * Copyright (c) 2015 Katy Coe <djkaty@start.no> <http://www.djkaty.com>
+ * 
+ * Full LGPL License: <http://www.gnu.org/licenses/lgpl.txt>
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+ 
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace Meebey.SmartIrc4net
+{
+    /// <summary>
+    /// Class representing a single IRCv3 capability
+    /// </summary>
+    public class Capability
+    {
+        private IdnMapping mapping = new IdnMapping();
+        private string _Vendor;
+
+        /// <summary>
+        /// Vendor
+        /// </summary>
+        public string Vendor {
+            get {
+                // If value is already Punycode, converts it to a normal string, otherwise does nothing
+                return mapping.GetUnicode(_Vendor);
+            }
+            private set {
+                // If value is already Punycode, does nothing, otherwise converts to Punycode
+                _Vendor = mapping.GetAscii(value);
+            }
+        }
+
+        /// <summary>
+        /// Vendor as Punycode
+        /// </summary>
+        public string VendorAsPunycode {
+            get {
+                return mapping.GetAscii(_Vendor);
+            }
+        }
+
+        // NOTE: These two properties have private set only to shut up the Travis CI build tester on github
+
+        /// <summary>
+        /// Capability name
+        /// </summary>
+        public string Name { get; private set; }
+
+        /// <summary>
+        /// Optional capability parameter
+        /// </summary>
+        public string Option { get; private set; }
+
+        /// <summary>
+        /// Get the capability in human-readable format
+        /// </summary>
+        /// <returns></returns>
+        public override string ToString()
+        {
+            return (VendorAsPunycode != "" ? VendorAsPunycode + "/" : "") + Name + (Option != "" ? "=" + Option : "");
+        }
+
+        /// <summary>
+        /// Create a new capability
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="vendor"></param>
+        /// <param name="option"></param>
+        public Capability(string name, string vendor = "", string option = "")
+        {
+            Vendor = vendor;
+            Name = name;
+            Option = option;
+        }
+
+        /// <summary>
+        /// Convert a human-readable capability into a new Capability object
+        /// </summary>
+        /// <param name="capstr"></param>
+        /// <returns></returns>
+        public static Capability FromString(string capstr)
+        {
+            Match m = Regex.Match(capstr.Trim(), @"^(?<vendor>.*?(?=/))?/?(?<name>[^=]+)=?(?<option>.*)?$");
+
+            if (m.Success)
+                return new Capability(m.Groups["name"].Value, m.Groups["vendor"].Value, m.Groups["option"].Value);
+            else
+                throw new ArgumentException("Invalid capability string supplied: " + capstr);
+        }
+
+        /// <summary>
+        /// Get an array of Capability objects from a space-delimited string of capabilities
+        /// </summary>
+        /// <param name="caplist"></param>
+        /// <returns></returns>
+        public static IEnumerable<Capability> FromStrings(string caplist)
+        {
+            return from cap in caplist.Trim().Split(new char[] { ' ' }) select FromString(cap);
+        }
+    }
+}

--- a/src/IrcCommands/IrcCommands.cs
+++ b/src/IrcCommands/IrcCommands.cs
@@ -28,7 +28,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text;
+using System.Linq;
 
 namespace Meebey.SmartIrc4net
 {
@@ -539,8 +539,98 @@ namespace Meebey.SmartIrc4net
                                        newModeParameterChunks.ToArray()));
             }
         }
-        
-#region RFC commands
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="priority"></param>
+        public void CapLs(Priority priority)
+        {
+            WriteLine("CAP LS 302", priority);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public void CapLs()
+        {
+            CapLs(Priority.Critical);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="priority"></param>
+        public void CapList(Priority priority)
+        {
+            WriteLine("CAP LIST", priority);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public void CapList()
+        {
+            CapList(Priority.Critical);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="caplist"></param>
+        /// <param name="priority"></param>
+        public void CapReq(Capability[] caplist, Priority priority)
+        {
+            CapReq(from cap in caplist select cap.ToString(), priority);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="caplist"></param>
+        /// <param name="priority"></param>
+        public void CapReq(IEnumerable<string> caplist, Priority priority)
+        {
+            WriteLine("CAP REQ :" + String.Join(" ", caplist), priority);
+            CapEnd(priority);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="caplist"></param>
+        public void CapReq(Capability[] caplist)
+        {
+            CapReq(from cap in caplist select cap.ToString(), Priority.Critical);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="caplist"></param>
+        public void CapReq(IEnumerable<string> caplist)
+        {
+            CapReq(caplist, Priority.Critical);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="priority"></param>
+        public void CapEnd(Priority priority)
+        {
+            WriteLine("CAP END", priority);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public void CapEnd()
+        {
+            CapEnd(Priority.Critical);
+        }
+
+        #region RFC commands
         /// <summary>
         /// 
         /// </summary>


### PR DESCRIPTION
This enables clients to send CAP LS, CAP LIST, CAP REQ and CAP END commands and receive events (OnCapLsReply, OnCapListReply, OnCapAckReply and OnCapNakReply) to query and notify about available, activated, allowed and denied caps and cap requests.

Fully compatible with IRCv3.2, partially compatible with IRCv3.1. Tested on Freenode, Efnet, IRCnet and Twitch.

With no code modifications the client will continue to use IRC 2 as per RFC2812. Use the IrcClient.UseIrcV3 property to enable caps negotiation. This negotiation is started by IrcClient as soon as the connection is made because although servers are lax, it is meant to be completed before attempting to log in.

Vendor-specialized and caps with optional arguments are supported as per the IRCv3 working group's spec at http://ircv3.net/specs/core/capability-negotiation-3.1.html and http://ircv3.net/specs/core/capability-negotiation-3.2.html.

Note that the code automatically calls CAP END after CAP REQ, this is a problem that can cause caps negotiation to be interspersed with login because IrcClient.Listen() is not called until afterwards, so the read thread has no opportunity to respond before login is attempted even though the data will be received by the connection. To use the truly correct flow, the code needs to be re-engineered so that it starts listening as soon as Connect() completes and makes Listen() unnecessary any longer (a moderately easy fix I believe). In practice, this causes no problems on any of the IRC servers I tested with.

IRCv3 message tags next :) (although I need this approved first as one depends on the other)