### PR TITLE
Fix race condition between starting PING stopwatch and receiving PONG

### DIFF
--- a/src/IrcConnection/IrcConnection.cs
+++ b/src/IrcConnection/IrcConnection.cs
@@ -1503,10 +1503,10 @@ namespace Meebey.SmartIrc4net
                             
                             // determines if it need to send another ping yet
                             if (last_pong_rcvd > _Connection._PingInterval) {
-                                _Connection.WriteLine(Rfc2812.Ping(_Connection.Address), Priority.Critical);
                                 _Connection.NextPingStopwatch.Stop();
                                 _Connection.PingStopwatch.Reset();
                                 _Connection.PingStopwatch.Start();
+                                _Connection.WriteLine(Rfc2812.Ping(_Connection.Address), Priority.Critical);
                             } // else connection is fine, just continue
                         } else {
                             if (_Connection.IsDisconnecting) {


### PR DESCRIPTION
Looks like my previous PR introduced a race condition that I then observed in the wild.

If the server responds with a `PONG` message quickly enough, the stopwatch swap-out performed after sending the `PING` message:

```
_Connection.WriteLine(Rfc2812.Ping(_Connection.Address), Priority.Critical);
_Connection.NextPingStopwatch.Stop();
_Connection.PingStopwatch.Reset();
_Connection.PingStopwatch.Start();
```

may come into a race with the stopwatch swap-out performed after receiving a PONG message:

```
switch (command) {
    // ...
    case "PONG":
        PingStopwatch.Stop();
        NextPingStopwatch.Reset();
        NextPingStopwatch.Start();
        // ...
        break;
}
```

Avoid this by moving the call sending the PING message until after the swap-out (top block).